### PR TITLE
Patch to fix bug 353455 (Cannot render images sequences)

### DIFF
--- a/renderer/kdenlive_render.cpp
+++ b/renderer/kdenlive_render.cpp
@@ -68,14 +68,8 @@ int main(int argc, char **argv)
         QString profile = args.takeFirst();
         QString rendermodule = args.takeFirst();
         QString player = args.takeFirst();
-        QByteArray srcString = args.takeFirst().toUtf8();
-        QUrl srcurl = QUrl::fromEncoded(srcString);
-        QString src = srcurl.path();
-        // The QUrl path() strips the consumer: protocol, so re-add it if necessary
-        if (srcString.startsWith("consumer:"))
-            src.prepend(QLatin1String("consumer:"));
-        QUrl desturl = QUrl::fromEncoded(args.takeFirst().toUtf8());
-        QString dest = desturl.path();
+        QString src = args.takeFirst();
+        QString dest = args.takeFirst();
         bool dualpass = false;
         bool doerase;
         QString vpre;


### PR DESCRIPTION
Could not export image sequences due to path() was decoding %05 symbols.
Additional details are described in bug report https://bugs.kde.org/show_bug.cgi?id=353455