### PR TITLE
new config UI for clip+transition corner types, with corresponding clip+transition painting code updates

### DIFF
--- a/src/kdenlivesettings.kcfg
+++ b/src/kdenlivesettings.kcfg
@@ -234,6 +234,11 @@
     <label>Use timeline zone as in/out editing points.</label>
       <default>false</default>
     </entry>
+      
+    <entry name="clipcornertype" type="Int">
+        <label>Timeline clip corners.</label>
+        <default>0</default>
+    </entry>
 
     </group>
 

--- a/src/kdenlivesettings.kcfg
+++ b/src/kdenlivesettings.kcfg
@@ -237,7 +237,7 @@
       
     <entry name="clipcornertype" type="Int">
         <label>Timeline clip corners.</label>
-        <default>0</default>
+        <default>1</default>
     </entry>
 
     </group>

--- a/src/timeline/clipitem.cpp
+++ b/src/timeline/clipitem.cpp
@@ -584,7 +584,11 @@ void ClipItem::paint(QPainter *painter,
     QPainterPath p;
     p.addRect(mappedExposed);
     QPainterPath q;
-    q.addRoundedRect(mapped, 3, 3);
+    if (KdenliveSettings::clipcornertype() == 0) {
+        q.addRoundedRect(mapped, 3, 3);
+    } else {
+        q.addRect(mapped);
+    }
     painter->setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform, false);
     painter->setClipPath(p.intersected(q));
     painter->setPen(Qt::NoPen);
@@ -915,8 +919,15 @@ void ClipItem::paint(QPainter *painter,
     painter->setClipping(false);
     painter->setRenderHint(QPainter::Antialiasing, true);
     framePen.setWidthF(1.5);
+    if (KdenliveSettings::clipcornertype() == 1) {
+        framePen.setJoinStyle(Qt::MiterJoin);
+    }
     painter->setPen(framePen);
-    painter->drawRoundedRect(mapped.adjusted(0.5, 0, -0.5, 0), 3, 3);
+    if (KdenliveSettings::clipcornertype() == 0) {
+        painter->drawRoundedRect(mapped.adjusted(0.5, 0, -0.5, 0), 3, 3);
+    } else {
+        painter->drawRect(mapped.adjusted(0.5, 0, -0.5, 0));
+    }
 }
 
 const QString &ClipItem::getBinId() const

--- a/src/timeline/transition.cpp
+++ b/src/timeline/transition.cpp
@@ -185,7 +185,11 @@ void Transition::paint(QPainter *painter,
     p.addRect(exposed);
     
     QPainterPath q;
-    q.addRoundedRect(mapped, 3, 3);
+    if (KdenliveSettings::clipcornertype() == 0) {
+        q.addRoundedRect(mapped, 3, 3);
+    } else {
+        q.addRect(mapped);
+    }
     painter->setClipPath(p.intersected(q));
     painter->fillRect(exposed, brush());
     const QString text = m_name + (m_forceTransitionTrack ? QStringLiteral("|>") : QString());
@@ -209,10 +213,17 @@ void Transition::paint(QPainter *painter,
     painter->drawText(txtBounding, Qt::AlignCenter, text);
 
     // Draw frame
+    if (KdenliveSettings::clipcornertype() == 1) {
+        framePen.setJoinStyle(Qt::MiterJoin);
+    }
     painter->setPen(framePen);
     painter->setClipping(false);
     painter->setRenderHint(QPainter::Antialiasing, true);
-    painter->drawRoundedRect(mapped.adjusted(0, 0, -0.5, -0.5), 3, 3);
+    if (KdenliveSettings::clipcornertype() == 0) {
+        painter->drawRoundedRect(mapped.adjusted(0, 0, -0.5, -0.5), 3, 3);
+    } else {
+        painter->drawRect(mapped.adjusted(0, 0, -0.5, -0.5));
+    }
 }
 
 int Transition::type() const

--- a/src/ui/configtimeline_ui.ui
+++ b/src/ui/configtimeline_ui.ui
@@ -11,44 +11,6 @@
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="7" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_4">
-     <item>
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Timeline corners</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="kcfg_clipcornertype">
-       <item>
-        <property name="text">
-         <string>Rounded</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Straight</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
    <item row="1" column="0" colspan="4">
     <widget class="QCheckBox" name="kcfg_ffmpegaudiothumbnails">
      <property name="text">
@@ -183,6 +145,44 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="7" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Timeline clip and transition corners</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="kcfg_clipcornertype">
+       <item>
+        <property name="text">
+         <string>Rounded</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Straight</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/src/ui/configtimeline_ui.ui
+++ b/src/ui/configtimeline_ui.ui
@@ -11,6 +11,44 @@
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="7" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Timeline corners</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="kcfg_clipcornertype">
+       <item>
+        <property name="text">
+         <string>Rounded</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Straight</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
    <item row="1" column="0" colspan="4">
     <widget class="QCheckBox" name="kcfg_ffmpegaudiothumbnails">
      <property name="text">
@@ -133,7 +171,7 @@
      </layout>
     </widget>
    </item>
-   <item row="7" column="0">
+   <item row="11" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>


### PR DESCRIPTION
- new timeline configuration UI element for selecting the type of clip+transition corners: rounded (as before) or straight.
- correspondingly updated painting code for clips and transitions in timeline.