### PR TITLE
Revising the "Save Layout As" menu options to be more congruent - layoutmanagement.cpp

### DIFF
--- a/src/layoutmanagement.cpp
+++ b/src/layoutmanagement.cpp
@@ -31,7 +31,7 @@ LayoutManagement::LayoutManagement(QObject* parent) :
         load->setData('_' + QString::number(i));
         layoutActions->addAction("load_layout" + QString::number(i), load);
         m_loadLayout->addAction(load);
-        QAction *save = new QAction(QIcon(), i18n("Save As Layout %1", i), this);
+        QAction *save = new QAction(QIcon(), i18n("Layout %1", i), this);
         save->setData('_' + QString::number(i));
         layoutActions->addAction("save_layout" + QString::number(i), save);
     }
@@ -66,7 +66,7 @@ void LayoutManagement::initializeLayouts()
                 }
                 for (int j = 0; j < saveActions.count(); ++j) {
                     if (saveActions.at(j)->data().toString().endsWith('_' + QString::number(i))) {
-                        saveActions[j]->setText(i18n("Save as %1", layoutName));
+                        saveActions[j]->setText(i18n("%1", layoutName));
                         saveActions[j]->setData(key);
                         break;
                     }


### PR DESCRIPTION
Changed the "Save As" in the "Save Layout As" menu option: removed the "Save as" and simply showed the layout name. Now it's more congruent with the Load Layout menu options.

This is my first time making a pull request for Kdenlive -- feel free to let me know if there's anything else I need to do. :) Cheers.