### PR TITLE
Fix audio alignment race condition and off-by-one errors

### DIFF
--- a/src/lib/audio/audioCorrelation.h
+++ b/src/lib/audio/audioCorrelation.h
@@ -44,7 +44,7 @@ public:
 
     /**
       Adds a child envelope that will be aligned to the reference
-      envelope. This function returns immediately, the alinment
+      envelope. This function returns immediately, the alignment
       computation is done asynchronously. When done, the signal
       gotAudioAlignData will be emitted. Similarly to the main
       envelope, the computation of the envelope must not be started

--- a/src/lib/audio/audioCorrelation.h
+++ b/src/lib/audio/audioCorrelation.h
@@ -14,6 +14,7 @@
 #include "audioCorrelationInfo.h"
 #include "audioEnvelope.h"
 #include "definitions.h"
+#include <memory>
 #include <QList>
 
 /**
@@ -27,14 +28,31 @@ class AudioCorrelation : public QObject
 {
     Q_OBJECT
 public:
-    /// AudioCorrelation will take ownership of mainTrackEnvelope
-    explicit AudioCorrelation(AudioEnvelope *mainTrackEnvelope);
+    /**
+      @param mainTrackEnvelope Envelope of the reference track. Its
+                               actual computation will be started in
+                               this contructor
+                               (i.e. mainTrackEnvelope->StartComputeEnvelope()
+                               will be called). The computation of the
+                               envelop must not be started when passed
+                               to this contructor
+                               (i.e. mainTrackEnvelope->HasComputationStarted()
+                               must return false).
+    */
+    explicit AudioCorrelation(std::unique_ptr<AudioEnvelope> mainTrackEnvelope);
     ~AudioCorrelation();
 
     /**
+      Adds a child envelope that will be aligned to the reference
+      envelope. This function returns immediately, the alinment
+      computation is done asynchronously. When done, the signal
+      gotAudioAlignData will be emitted. Similarly to the main
+      envelope, the computation of the envelope must not be started
+      when it is passed to this object.
+
       This object will take ownership of the passed envelope.
       */
-    void addChild(AudioEnvelope *envelope);
+    void addChild(AudioEnvelope* envelope);
 
     const AudioCorrelationInfo *info(int childIndex) const;
     int getShift(int childIndex) const;
@@ -48,12 +66,19 @@ public:
                           qint64 *correlation,
                           qint64 *out_max = nullptr);
 private:
-    AudioEnvelope *m_mainTrackEnvelope;
+    std::unique_ptr<AudioEnvelope> m_mainTrackEnvelope;
 
     QList<AudioEnvelope *> m_children;
     QList<AudioCorrelationInfo *> m_correlations;
 
 private slots:
+    /**
+      This is invoked when the child envelope is computed. This
+      triggers the actual computations of the cross-correlation for
+      aligning the envelope to the reference envelope.
+
+      Takes ownership of @p envelope.
+    */
     void slotProcessChild(AudioEnvelope *envelope);
     void slotAnnounceEnvelope();
 

--- a/src/lib/audio/audioEnvelope.cpp
+++ b/src/lib/audio/audioEnvelope.cpp
@@ -15,111 +15,105 @@
 #include <QImage>
 #include <QTime>
 #include <QtConcurrent>
+#include <algorithm>
 #include <cmath>
 
 AudioEnvelope::AudioEnvelope(const QString &url, Mlt::Producer *producer, int offset, int length, int track, int startPos) :
-    m_envelope(nullptr),
     m_offset(offset),
-    m_length(length),
     m_track(track),
     m_startpos(startPos),
-    m_envelopeSize(producer->get_length()),
-    m_envelopeMax(0),
-    m_envelopeMean(0),
-    m_envelopeStdDev(0),
-    m_envelopeStdDevCalculated(false),
-    m_envelopeIsNormalized(false)
+    m_envelopeSize(producer->get_length())
 {
     // make a copy of the producer to avoid audio playback issues
     QString path = QString::fromUtf8(producer->get("resource"));
     if (path == QLatin1String("<playlist>") || path == QLatin1String("<tractor>") || path == QLatin1String("<producer>")) {
         path = url;
     }
-    m_producer = new Mlt::Producer(*(producer->profile()), path.toUtf8().constData());
-    connect(&m_watcher, &QFutureWatcherBase::finished, this, &AudioEnvelope::slotProcessEnveloppe);
+    m_producer.reset(new Mlt::Producer(*(producer->profile()), path.toUtf8().constData()));
+    connect(&m_watcher, &QFutureWatcherBase::finished, this, [this]{ envelopeReady(this); } );
     if (!m_producer || !m_producer->is_valid()) {
         qCDebug(KDENLIVE_LOG) << "// Cannot create envelope for producer: " << path;
     }
-    m_info = new AudioInfo(m_producer);
+    m_info.reset(new AudioInfo(m_producer.get()));
 
     Q_ASSERT(m_offset >= 0);
-    if (m_length > 0) {
-        Q_ASSERT(m_length + m_offset <= m_envelopeSize);
-        m_envelopeSize = m_length;
+    if (length > 0) {
+        Q_ASSERT(length + m_offset <= m_envelopeSize);
+        m_envelopeSize = length;
     }
 }
 
 AudioEnvelope::~AudioEnvelope()
 {
-    if (m_envelope != nullptr) {
-        delete[] m_envelope;
-    }
-    delete m_info;
-    delete m_producer;
 }
 
-const qint64 *AudioEnvelope::envelope()
-{
-    if (m_envelope == nullptr) {
-        loadEnvelope();
-    }
-    return m_envelope;
-}
-int AudioEnvelope::envelopeSize() const
-{
-    return m_envelopeSize;
+void AudioEnvelope::startComputeEnvelope() {
+    m_audioSummary = QtConcurrent::run(this, &AudioEnvelope::loadAndNormalizeEnvelope);
+    m_watcher.setFuture(m_audioSummary);
 }
 
-void AudioEnvelope::loadEnvelope()
-{
-    Q_ASSERT(m_envelope == nullptr);
+bool AudioEnvelope::hasComputationStarted() const {
+    // An empty qFuture is canceled. QtConcurrent::run() returns a
+    // future that does not support cancelation, so this is a good way
+    // to check whether the computations have started.
+    return !m_audioSummary.isCanceled();
+}
 
+const AudioEnvelope::AudioSummary& AudioEnvelope::audioSummary() {
+    Q_ASSERT(hasComputationStarted());
+    m_audioSummary.waitForFinished();
+    Q_ASSERT(m_audioSummary.constBegin() != m_audioSummary.constEnd());
+    // We use this instead of m_audioSummary.result() in order to return
+    // a const reference instead of a copy.
+    return *m_audioSummary.constBegin();
+}
+
+const std::vector<qint64>& AudioEnvelope::envelope()
+{
+    // Blocks until the summary is available.
+    return audioSummary().audioAmplitudes;
+}
+
+AudioEnvelope::AudioSummary AudioEnvelope::loadAndNormalizeEnvelope() const {
     qCDebug(KDENLIVE_LOG) << "Loading envelope ...";
+
+    AudioSummary summary(m_envelopeSize);
 
     int samplingRate = m_info->info(0)->samplingRate();
     mlt_audio_format format_s16 = mlt_audio_s16;
     int channels = 1;
 
-    m_envelope = new qint64[m_envelopeSize];
-    m_envelopeMax = 0;
-    m_envelopeMean = 0;
-
     QTime t;
     t.start();
-    int count = 0;
     m_producer->seek(m_offset);
     m_producer->set_speed(1.0); // This is necessary, otherwise we don't get any new frames in the 2nd run.
-    for (int i = 0; i < m_envelopeSize; ++i) {
-        Mlt::Frame *frame = m_producer->get_frame(i);
+    for (int i = 0; i < summary.audioAmplitudes.size() ; ++i) {
+        std::unique_ptr<Mlt::Frame> frame(m_producer->get_frame(i));
         qint64 position = mlt_frame_get_position(frame->get_frame());
         int samples = mlt_sample_calculator(m_producer->get_fps(), samplingRate, position);
 
         qint16 *data = static_cast<qint16 *>(frame->get_audio(format_s16, samplingRate, channels, samples));
-
-        qint64 sum = 0;
+        summary.audioAmplitudes[i] = 0;
         for (int k = 0; k < samples; ++k) {
-            sum += abs(data[k]);
-        }
-        m_envelope[i] = sum;
-
-        m_envelopeMean += sum;
-        if (sum > m_envelopeMax) {
-            m_envelopeMax = sum;
-        }
-
-//        qCDebug(KDENLIVE_LOG) << position << '|' << m_producer->get_playtime()
-//                  << '-' << m_producer->get_in() << '+' << m_producer->get_out() << ' ';
-
-        delete frame;
-
-        count++;
-        if (m_length > 0 && count > m_length) {
-            break;
+          summary.audioAmplitudes[i] += abs(data[k]);
         }
     }
-    m_envelopeMean /= m_envelopeSize;
     qCDebug(KDENLIVE_LOG) << "Calculating the envelope (" << m_envelopeSize << " frames) took "
                           << t.elapsed() << " ms.";
+
+    qCDebug(KDENLIVE_LOG) << "Normalizing envelope ...";
+    const qint64 meanBeforeNormalization = std::accumulate(summary.audioAmplitudes.begin(),
+					    summary.audioAmplitudes.end(), 0LL) /
+      summary.audioAmplitudes.size();
+
+    // Normalize the envelope.
+    for (int i = 0; i < summary.audioAmplitudes.size(); ++i) {
+      summary.audioAmplitudes[i] -= meanBeforeNormalization;
+    }
+
+    summary.amplitudeMax = *std::max_element(summary.audioAmplitudes.begin(),
+					     summary.audioAmplitudes.end());
+    return summary;
 }
 
 int AudioEnvelope::track() const
@@ -132,57 +126,18 @@ int AudioEnvelope::startPos() const
     return m_startpos;
 }
 
-void AudioEnvelope::normalizeEnvelope(bool /*clampTo0*/)
-{
-    if (m_envelope == nullptr && !m_future.isRunning()) {
-        m_future = QtConcurrent::run(this, &AudioEnvelope::loadEnvelope);
-        m_watcher.setFuture(m_future);
-    }
-}
-
-void AudioEnvelope::slotProcessEnveloppe()
-{
-    if (!m_envelopeIsNormalized) {
-
-        m_envelopeMax = 0;
-        qint64 newMean = 0;
-        for (int i = 0; i < m_envelopeSize; ++i) {
-
-            m_envelope[i] -= m_envelopeMean;
-
-            /*if (clampTo0) {
-                if (m_envelope[i] < 0) { m_envelope[i] = 0; }
-            }*/
-
-            if (m_envelope[i] > m_envelopeMax) {
-                m_envelopeMax = m_envelope[i];
-            }
-
-            newMean += m_envelope[i];
-        }
-        m_envelopeMean = newMean / m_envelopeSize;
-
-        m_envelopeIsNormalized = true;
-    }
-    emit envelopeReady(this);
-
-}
-
 QImage AudioEnvelope::drawEnvelope()
 {
-    if (m_envelope == nullptr) {
-        loadEnvelope();
-    }
-
+  const AudioSummary& summary = audioSummary();
     QImage img(m_envelopeSize, 400, QImage::Format_ARGB32);
     img.fill(qRgb(255, 255, 255));
 
-    if (m_envelopeMax == 0) {
+    if (summary.amplitudeMax == 0) {
         return img;
     }
 
     for (int x = 0; x < img.width(); ++x) {
-        double fy = m_envelope[x] / double(m_envelopeMax) * img.height();
+        double fy = summary.audioAmplitudes[x] / double(summary.amplitudeMax) * img.height();
         for (int y = img.height() - 1; y > img.height() - 1 - fy; --y) {
             img.setPixel(x, y, qRgb(50, 50, 50));
         }
@@ -190,18 +145,15 @@ QImage AudioEnvelope::drawEnvelope()
     return img;
 }
 
-void AudioEnvelope::dumpInfo() const
+void AudioEnvelope::dumpInfo()
 {
-    if (m_envelope == nullptr) {
-        qCDebug(KDENLIVE_LOG) << "Envelope not generated, no information available.";
-    } else {
-        qCDebug(KDENLIVE_LOG) << "Envelope info"
-                              << "\n* size = " << m_envelopeSize
-                              << "\n* max = " << m_envelopeMax
-                              << "\n* µ = " << m_envelopeMean;
-        if (m_envelopeStdDevCalculated) {
-            qCDebug(KDENLIVE_LOG) << "* s = " << m_envelopeStdDev;
-        }
-    }
+  if (!m_audioSummary.isFinished()) {
+      qCDebug(KDENLIVE_LOG) << "Envelope not yet generated, no information available.";
+  } else {
+      const AudioSummary& summary = audioSummary();
+      qCDebug(KDENLIVE_LOG) << "Envelope info"
+			    << "\n* size = " << summary.audioAmplitudes.size()
+			    << "\n* max = " << summary.amplitudeMax;
+  }
 }
 

--- a/src/lib/audio/fftCorrelation.cpp
+++ b/src/lib/audio/fftCorrelation.cpp
@@ -18,6 +18,7 @@ extern "C"
 #include "kdenlive_debug.h"
 #include <QTime>
 #include <algorithm>
+#include <vector>
 
 void FFTCorrelation::correlate(const qint64 *left, const int leftSize,
                                const qint64 *right, const int rightSize,
@@ -97,30 +98,27 @@ void FFTCorrelation::convolve(const float *left, const int leftSize,
     while (size / 2 < largestSize) {
         size = size << 1;
     }
-
+    const int fft_size = size / 2 + 1;
     kiss_fftr_cfg fftConfig = kiss_fftr_alloc(size, false, nullptr, nullptr);
     kiss_fftr_cfg ifftConfig = kiss_fftr_alloc(size, true, nullptr, nullptr);
-    kiss_fft_cpx leftFFT[size / 2 + 1];
-    kiss_fft_cpx rightFFT[size / 2 + 1];
-    kiss_fft_cpx correlatedFFT[size / 2 + 1];
+    std::vector<kiss_fft_cpx> leftFFT(fft_size);
+    std::vector<kiss_fft_cpx> rightFFT(fft_size);
+    std::vector<kiss_fft_cpx> correlatedFFT(fft_size);
 
     // Fill in the data into our new vectors with padding
-    float *leftData = new float[size];
-    float *rightData = new float[size];
-    float *convolved = new float[size];
+    std::vector<float> leftData(size, 0);
+    std::vector<float> rightData(size, 0);
+    std::vector<float> convolved(size);
 
-    std::fill(leftData, leftData + size, 0);
-    std::fill(rightData, rightData + size, 0);
-
-    std::copy(left, left + leftSize, leftData);
-    std::copy(right, right + rightSize, rightData);
+    std::copy(left, left + leftSize, leftData.begin());
+    std::copy(right, right + rightSize, rightData.begin());
 
     // Fourier transformation of the vectors
-    kiss_fftr(fftConfig, leftData, leftFFT);
-    kiss_fftr(fftConfig, rightData, rightFFT);
+    kiss_fftr(fftConfig, &leftData[0], &leftFFT[0]);
+    kiss_fftr(fftConfig, &rightData[0], &rightFFT[0]);
 
     // Convolution in spacial domain is a multiplication in fourier domain. O(n).
-    for (int i = 0; i < size / 2 + 1; ++i) {
+    for (int i = 0; i < correlatedFFT.size(); ++i) {
         correlatedFFT[i].r = leftFFT[i].r * rightFFT[i].r - leftFFT[i].i * rightFFT[i].i;
         correlatedFFT[i].i = leftFFT[i].r * rightFFT[i].i + leftFFT[i].i * rightFFT[i].r;
     }
@@ -131,16 +129,12 @@ void FFTCorrelation::convolve(const float *left, const int leftSize,
     *out_convolved = 0;
     int out_size = leftSize + rightSize + 1;
 
-    kiss_fftri(ifftConfig, correlatedFFT, convolved);
-    std::copy(convolved, convolved + out_size - 1, out_convolved + 1);
+    kiss_fftri(ifftConfig, &correlatedFFT[0], &convolved[0]);
+    std::copy(convolved.begin(), convolved.begin() + out_size - 1, out_convolved + 1);
 
     // Finally some cleanup.
     kiss_fftr_free(fftConfig);
     kiss_fftr_free(ifftConfig);
-
-    delete[] leftData;
-    delete[] rightData;
-    delete[] convolved;
 
     qCDebug(KDENLIVE_LOG) << "FFT convolution computed. Time taken: " << time.elapsed() << " ms";
 }

--- a/src/lib/audio/fftCorrelation.cpp
+++ b/src/lib/audio/fftCorrelation.cpp
@@ -61,7 +61,7 @@ void FFTCorrelation::correlate(const qint64 *left, const int leftSize,
         }
     }
 
-    // One side needs to be reverted, since multiplication in frequency domain (fourier space)
+    // One side needs to be reversed, since multiplication in frequency domain (fourier space)
     // calculates the convolution: \sum l[x]r[N-x] and not the correlation: \sum l[x]r[x]
     for (int i = 0; i < leftSize; ++i) {
         leftF[i] = double(left[i]) / maxLeft;
@@ -100,9 +100,9 @@ void FFTCorrelation::convolve(const float *left, const int leftSize,
 
     kiss_fftr_cfg fftConfig = kiss_fftr_alloc(size, false, nullptr, nullptr);
     kiss_fftr_cfg ifftConfig = kiss_fftr_alloc(size, true, nullptr, nullptr);
-    kiss_fft_cpx leftFFT[size / 2];
-    kiss_fft_cpx rightFFT[size / 2];
-    kiss_fft_cpx correlatedFFT[size / 2];
+    kiss_fft_cpx leftFFT[size / 2 + 1];
+    kiss_fft_cpx rightFFT[size / 2 + 1];
+    kiss_fft_cpx correlatedFFT[size / 2 + 1];
 
     // Fill in the data into our new vectors with padding
     float *leftData = new float[size];
@@ -120,7 +120,7 @@ void FFTCorrelation::convolve(const float *left, const int leftSize,
     kiss_fftr(fftConfig, rightData, rightFFT);
 
     // Convolution in spacial domain is a multiplication in fourier domain. O(n).
-    for (int i = 0; i < size / 2; ++i) {
+    for (int i = 0; i < size / 2 + 1; ++i) {
         correlatedFFT[i].r = leftFFT[i].r * rightFFT[i].r - leftFFT[i].i * rightFFT[i].i;
         correlatedFFT[i].i = leftFFT[i].r * rightFFT[i].i + leftFFT[i].i * rightFFT[i].r;
     }

--- a/src/lib/audio/fftCorrelation.h
+++ b/src/lib/audio/fftCorrelation.h
@@ -25,7 +25,7 @@ public:
     /**
       Computes the convolution between \c left and \c right.
       \c out_correlated must be a pre-allocated vector of size
-      \c leftSize + \c rightSize.
+      \c leftSize + \c rightSize + 1.
       */
     static void convolve(const float *left, const int leftSize,
                          const float *right, const int rightSize,
@@ -34,7 +34,7 @@ public:
     /**
       Computes the correlation between \c left and \c right.
       \c out_correlated must be a pre-allocated vector of size
-      \c leftSize + \c rightSize.
+      \c leftSize + \c rightSize + 1.
       */
     static void correlate(const qint64 *left, const int leftSize,
                           const qint64 *right, const int rightSize,

--- a/src/timeline/customtrackview.cpp
+++ b/src/timeline/customtrackview.cpp
@@ -17,6 +17,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA          *
  ***************************************************************************/
 
+#include <memory>
+
 #include "customtrackview.h"
 #include "timeline.h"
 #include "track.h"
@@ -7355,8 +7357,8 @@ void CustomTrackView::setAudioAlignReference()
                 qCWarning(KDENLIVE_LOG) << "couldn't load producer for clip " << clip->getBinId() << " on track " << clip->track();
                 return;
             }
-            AudioEnvelope *envelope = new AudioEnvelope(clip->binClip()->url(), prod);
-            m_audioCorrelator = new AudioCorrelation(envelope);
+            std::unique_ptr<AudioEnvelope> envelope(new AudioEnvelope(clip->binClip()->url(), prod));
+            m_audioCorrelator = new AudioCorrelation(std::move(envelope));
             connect(m_audioCorrelator, &AudioCorrelation::gotAudioAlignData, this, &CustomTrackView::slotAlignClip);
             connect(m_audioCorrelator, &AudioCorrelation::displayMessage, this, &CustomTrackView::displayMessage);
             emit displayMessage(i18n("Processing audio, please wait."), ProcessingJobMessage);


### PR DESCRIPTION
This patchset fixes a race condition when aligning tracks based on audio. Namely, when one clicks "Align Audio to Reference" before the computations triggered by "Set Audio Reference" have completed, the alignment can be completely arbitrary.

It also fixes a few off-by-one errors, and generally improves the code.
