### PR TITLE
Add link to community wiki to readme

### DIFF
--- a/README
+++ b/README
@@ -10,6 +10,9 @@ https://kdenlive.org
 Building from source
 ====================
 
+For more complete instructions see:
+https://community.kde.org/Kdenlive/Development
+
 You will first need to install development headers dependencies
 from your system (mainly KDE and MLT).
 


### PR DESCRIPTION
The dependencies info in the readme is woefully inadequate, and the wiki seems to be more helpful.