### PR TITLE
Fix a python exception under Windows when using OpenTimeLineIO

### DIFF
--- a/data/scripts/checkpackages.py
+++ b/data/scripts/checkpackages.py
@@ -42,7 +42,7 @@ if len(required) == 0:
     print_help()
     sys.exit("Error: You need to provide at least one package name")
 
-installed = {pkg.name for pkg in importlib.metadata.distributions()}
+installed = {pkg.metadata['Name'] for pkg in importlib.metadata.distributions()}
 installed = {x.lower() for x in installed}
 missing = required - installed
 


### PR DESCRIPTION
Fix a python exception under Windows when using OpenTimeLineIO

Without this fix, running python checkpackages.py --check opentimelineio

would generate :
```

Traceback (most recent call last):
  File "checkpackages.py", line 50, in <module>
    installed = {pkg.name for pkg in importlib.metadata.distributions()}
  File "checkpackages.py", line 50, in <setcomp>
    installed = {pkg.name for pkg in importlib.metadata.distributions()}
AttributeError: 'PathDistribution' object has no attribute 'name'
```

Maybe it used to work under linux. Or maybe this was an interface from pkgresources that has not been duplicated in importlib.metadata and this went unnoticed