### PR TITLE
Serialize Qt title thumbnail rendering

### DIFF
--- a/src/bin/projectclip.cpp
+++ b/src/bin/projectclip.cpp
@@ -3119,7 +3119,8 @@ QImage ProjectClip::fetchPixmap(int framePosition)
         frame->set("consumer.top_field_first", -1);
         frame->set("consumer.rescale", "nearest");
         int fullWidth = qRound(imageHeight * pCore->getCurrentDar());
-        return KThumb::getFrame(frame.get(), imageWidth, imageHeight, fullWidth);
+        return KThumb::getFrame(frame.get(), imageWidth, imageHeight, fullWidth,
+                                KThumb::needsSerializedQtRendering(clipType()));
     }
     return QImage();
 }

--- a/src/doc/kthumb.cpp
+++ b/src/doc/kthumb.cpp
@@ -7,12 +7,32 @@ SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-KDE-Accepted-GPL
 
 #include "kthumb.h"
 #include "core.h"
+#include "definitions.h"
 #include "kdenlivesettings.h"
 #include "profiles/profilemodel.hpp"
 
 #include <mlt++/Mlt.h>
 
+#include <QMutex>
+#include <QMutexLocker>
 #include <QPixmap>
+
+namespace {
+QMutex qtTitleThumbMutex;
+}
+
+bool KThumb::needsSerializedQtRendering(int clipType)
+{
+    switch (clipType) {
+    case ClipType::Text:
+    case ClipType::TextTemplate:
+    case ClipType::QText:
+        return true;
+    default:
+        return false;
+    }
+}
+
 // static
 QPixmap KThumb::getImage(const QUrl &url, int width, int height)
 {
@@ -99,7 +119,7 @@ QImage KThumb::getFrame(Mlt::Producer &producer, int framepos, int width, int he
 }
 
 // static
-QImage KThumb::getFrame(Mlt::Frame *frame, int width, int height, int scaledWidth)
+QImage KThumb::getFrame(Mlt::Frame *frame, int width, int height, int scaledWidth, bool serializeQtRendering)
 {
     if (frame == nullptr || !frame->is_valid()) {
         qDebug() << "* * * *INVALID FRAME";
@@ -108,7 +128,15 @@ QImage KThumb::getFrame(Mlt::Frame *frame, int width, int height, int scaledWidt
     int ow = width;
     int oh = height;
     mlt_image_format format = mlt_image_rgba;
-    const uchar *imagedata = frame->get_image(format, ow, oh);
+    const uchar *imagedata = nullptr;
+    if (serializeQtRendering) {
+        // Qt-backed MLT producers render through Qt graphics/font code; keep
+        // those thumbnail renders single-threaded.
+        QMutexLocker lock(&qtTitleThumbMutex);
+        imagedata = frame->get_image(format, ow, oh);
+    } else {
+        imagedata = frame->get_image(format, ow, oh);
+    }
     if (imagedata) {
         QImage temp(ow, oh, QImage::Format_ARGB32);
         memcpy(temp.scanLine(0), imagedata, unsigned(ow * oh * 4));

--- a/src/doc/kthumb.h
+++ b/src/doc/kthumb.h
@@ -22,7 +22,8 @@ QPixmap getImage(const QUrl &url, int frame, int width, int height = -1, QMap<QS
 QPixmap getImageWithParams(const QUrl &url, QMap<QString, QString> params, int width, int height = -1);
 QImage getFrame(Mlt::Producer *producer, int framepos, int width, int height, int displayWidth = 0);
 QImage getFrame(Mlt::Producer &producer, int framepos, int width, int height, int displayWidth = 0);
-QImage getFrame(Mlt::Frame *frame, int width = 0, int height = 0, int scaledWidth = 0);
+QImage getFrame(Mlt::Frame *frame, int width = 0, int height = 0, int scaledWidth = 0, bool serializeQtRendering = false);
+bool needsSerializedQtRendering(int clipType);
 /** @brief Calculates image variance, useful to know if a thumbnail is interesting.
  *  @return an integer between 0 and 100. 0 means no variance, eg. black image while bigger values mean contrasted image
  * */

--- a/src/jobs/cachetask.cpp
+++ b/src/jobs/cachetask.cpp
@@ -78,6 +78,7 @@ void CacheTask::generateThumbnail(std::shared_ptr<ProjectClip> binClip)
         int imageHeight = pCore->thumbProfile().height();
         int imageWidth = pCore->thumbProfile().width();
         int fullWidth = qRound(imageHeight * pCore->getCurrentDar());
+        const bool serializeQtRendering = KThumb::needsSerializedQtRendering(binClip->clipType());
         const QString clipId = QString::number(m_owner.itemId);
         for (int i : m_frames) {
             int val = qMax(1, 100 * count / size);
@@ -101,7 +102,7 @@ void CacheTask::generateThumbnail(std::shared_ptr<ProjectClip> binClip)
                 frame->set("consumer.deinterlacer", "onefield");
                 frame->set("consumer.top_field_first", -1);
                 frame->set("consumer.rescale", "nearest");
-                const QImage result = KThumb::getFrame(frame.get(), imageWidth, imageHeight, fullWidth);
+                const QImage result = KThumb::getFrame(frame.get(), imageWidth, imageHeight, fullWidth, serializeQtRendering);
                 if (!result.isNull() && !m_isCanceled) {
                     ThumbnailCache::get()->storeThumbnail(clipId, i, result, true);
                 }

--- a/src/jobs/cliploadtask.cpp
+++ b/src/jobs/cliploadtask.cpp
@@ -257,10 +257,11 @@ void ClipLoadTask::generateThumbnail(std::shared_ptr<ProjectClip> binClip, std::
                     int imageHeight(pCore->thumbProfile().height());
                     int imageWidth(pCore->thumbProfile().width());
                     int fullWidth(qRound(imageHeight * pCore->getCurrentDar()));
+                    const bool serializeQtRendering = KThumb::needsSerializedQtRendering(binClip->clipType());
                     if (m_isCanceled.loadAcquire() || pCore->taskManager.isBlocked()) {
                         return;
                     }
-                    QImage result = KThumb::getFrame(frame.get(), imageWidth, imageHeight, fullWidth);
+                    QImage result = KThumb::getFrame(frame.get(), imageWidth, imageHeight, fullWidth, serializeQtRendering);
                     if (result.isNull() && !m_isCanceled.loadAcquire()) {
                         qDebug() << "+++++\nINVALID RESULT IMAGE\n++++++++++++++";
                         result = QImage(fullWidth, imageHeight, QImage::Format_ARGB32_Premultiplied);

--- a/src/timeline2/view/qmltypes/thumbnailprovider.cpp
+++ b/src/timeline2/view/qmltypes/thumbnailprovider.cpp
@@ -56,7 +56,8 @@ QImage ThumbnailProvider::requestImage(const QString &id, QSize *size, const QSi
                     prod->attach(padder);
                     prod->attach(converter);
                 }
-                result = makeThumbnail(std::move(prod), frameNumber, requestedSize);
+                result = makeThumbnail(std::move(prod), frameNumber, requestedSize,
+                                       KThumb::needsSerializedQtRendering(binClip->clipType()));
                 ThumbnailCache::get()->storeThumbnail(binId, frameNumber, result, false);
             }
         }
@@ -65,7 +66,7 @@ QImage ThumbnailProvider::requestImage(const QString &id, QSize *size, const QSi
     return result;
 }
 
-QImage ThumbnailProvider::makeThumbnail(std::unique_ptr<Mlt::Producer> producer, int frameNumber, const QSize &requestedSize)
+QImage ThumbnailProvider::makeThumbnail(std::unique_ptr<Mlt::Producer> producer, int frameNumber, const QSize &requestedSize, bool serializeQtRendering)
 {
     Q_UNUSED(requestedSize)
     producer->seek(frameNumber);
@@ -80,5 +81,5 @@ QImage ThumbnailProvider::makeThumbnail(std::unique_ptr<Mlt::Producer> producer,
     int imageHeight = pCore->thumbProfile().height();
     int imageWidth = pCore->thumbProfile().width();
     int fullWidth = qRound(imageHeight * pCore->getCurrentDar());
-    return KThumb::getFrame(frame.get(), imageWidth, imageHeight, fullWidth);
+    return KThumb::getFrame(frame.get(), imageWidth, imageHeight, fullWidth, serializeQtRendering);
 }

--- a/src/timeline2/view/qmltypes/thumbnailprovider.h
+++ b/src/timeline2/view/qmltypes/thumbnailprovider.h
@@ -23,5 +23,5 @@ public:
 
 private:
     Mlt::Profile m_profile;
-    QImage makeThumbnail(std::unique_ptr<Mlt::Producer> producer, int frameNumber, const QSize &requestedSize);
+    QImage makeThumbnail(std::unique_ptr<Mlt::Producer> producer, int frameNumber, const QSize &requestedSize, bool serializeQtRendering);
 };


### PR DESCRIPTION
## Summary

Serialize thumbnail rendering for Qt title/text producers across the thumbnail/cache paths.

The collected crash evidence pointed at concurrent title thumbnail extraction entering Qt/font rendering from multiple worker paths. This adds a shared mutex and uses it only for title/text producers when calling `frame->get_image()`, keeping non-title clips on the existing parallel path.

## Validation

- `git diff --check`
- Attempted CMake configuration, but local dependencies were missing: KF6 `TextWidgets` and `Purpose`

The change is therefore compile-unverified in this sandbox, but it is limited to the existing thumbnail extraction call sites and uses the same title/text producer detection across them.
